### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @guardian/digital-cms

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @guardian/content-platforms
-* @guardian/digital-cms
+* @guardian/content-platforms @guardian/digital-cms

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @guardian/content-platforms
+* @guardian/digital-cms


### PR DESCRIPTION
This PR adds a CODEOWNERS file assigning the repository to @guardian/content-platforms and @guardian/digital-cms. This is primarily to keep track of which repositories our teams maintain.

GitHub will also automatically add these teams as reviewers if a PR is made on this repo.