### PR TITLE
Replace deprecated `bucket` riff-raff parameter & bump to fixed Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "delete-expired-formstack-data-lambdas"
 
 version := "0.1"
 
-scalaVersion := "2.13.4"
+scalaVersion := "2.13.10"
 
 val circeVersion = "0.13.0"
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
   delete-expired-formstack-data-lambdas:
     type: aws-lambda
     parameters:
-      bucket: delete-expired-formstack-data-dist
+      bucketSsmLookup: true
       fileName: app.jar
       functionNames:
         - formstack-form-deletion-lambda-

--- a/template.yaml
+++ b/template.yaml
@@ -7,6 +7,9 @@ Parameters:
     Type: String
     AllowedValues:
       - PROD # only PROD currently supported since there isn't a CODE Formstack environment
+  DistributionBucket:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /account/services/artifact.bucket
   FormstackAccountIdAccount1:
     Description: Id of the first Formstack account.
     Type: String
@@ -33,7 +36,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri:
-        Bucket: composer-dist
+        Bucket: !Ref DistributionBucket
         Key: !Sub ${Stage}/delete-expired-formstack-data-lambdas/app.jar
       Description: Lambda to delete old Formstack forms
       Events:
@@ -70,7 +73,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri:
-        Bucket: composer-dist
+        Bucket: !Ref DistributionBucket
         Key: !Sub ${Stage}/delete-expired-formstack-data-lambdas/app.jar
       Description: Lambda to delete old Formstack submissions
       # We want to invoke the lambda(s) for deleting forms submissions after the lambda(s) for deleting forms,

--- a/template.yaml
+++ b/template.yaml
@@ -33,7 +33,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri:
-        Bucket: delete-expired-formstack-data-dist
+        Bucket: composer-dist
         Key: !Sub ${Stage}/delete-expired-formstack-data-lambdas/app.jar
       Description: Lambda to delete old Formstack forms
       Events:
@@ -70,7 +70,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri:
-        Bucket: delete-expired-formstack-data-dist
+        Bucket: composer-dist
         Key: !Sub ${Stage}/delete-expired-formstack-data-lambdas/app.jar
       Description: Lambda to delete old Formstack submissions
       # We want to invoke the lambda(s) for deleting forms submissions after the lambda(s) for deleting forms,


### PR DESCRIPTION
The `bucket` parameter in riff-raff.yaml has been deprecated in favour of `bucketSsmLookup`.  This causes Riffraff to look up the destination bucket from a parameter in the AWS account's SSM parameter store instead of being hard-coded.  We are currently getting deprecation warnings when deploying this project in riffraff, and merging this PR should fix that by replacing the deprecated parameter with the new one.