### PR TITLE
Update cloudformation to get its parameters from SSM.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -12,25 +12,32 @@ Parameters:
     Default: /account/services/artifact.bucket
   FormstackAccountIdAccount1:
     Description: Id of the first Formstack account.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackAccountIdAccount1
   FormstackAccessTokenAccount1:
     Description: Used to authenticate against the Formstack API for account one.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackAccessTokenAccount1
   FormstackEncryptionPasswordAccount1:
     Description: Used to decrypt Formstack submissions for account 1.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackEncryptionPasswordAccount1
   FormstackAccountIdAccount2:
     Description: Id of the second Formstack account.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackAccountIdAccount2
   FormstackAccessTokenAccount2:
     Description: Used to authenticate against the Formstack API for account 2.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackAccessTokenAccount2
   FormstackEncryptionPasswordAccount2:
     Description: Used to decrypt Formstack submissions for account 2.
-    Type: String
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /PROD/formstack/delete-expired-formstack-data/FormstackEncryptionPasswordAccount2
   AlarmTopic:
     Description: ARN of SNS topic to send messages to when a Formstack alarm transitions to the Alarm state.
     Type: String
+    Default: /PROD/formstack/delete-expired-formstack-data/AlarmTopic
 Resources:
   FormDeletionLambda:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
## What does this change?

- Updates the Cloudformation template to read parameter values from SSM instead of requiring them directly.

This is so that we can save the current values elsewhere and delete the stack, since the lambdas are currently out of commission and waiting for a decision on what should be done about data management on Formstack

The corresponding parameters have already been created in the Composer account and have been populated with the existing values from the deployed cloudformation

## How to test

Try to deploy the existing stack. You'll need to paste the `default` values for the parameters over the existing values as the meaning has changed (they now require SSM path instead of actual value).
You should not see any actual changes required and therefore won't be able to deploy the change.

## How can we measure success?

Able to "just delete" the stack safe in the knowledge that we can "just redeploy" it if asked to

## Have we considered potential risks?

n/a. This is the recommended way of storing parameters going forwards so it's a positive move anyway, and it removes any risk of losing the existing parameter values
