### PR TITLE
Remove the debug flag from snyk

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -10,7 +10,6 @@ jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
     with:
-      DEBUG: true
       ORG: guardian-capi
       SKIP_NODE: true
     secrets:


### PR DESCRIPTION
When using the debug flag in snyk, it attempts to pass the `—debug` flag to the build tool of the language used for the project. When a repo contains python or go, this can cause compatibility issues as they don’t accept debug flags. We’ve detected that this repo contains either a python or a go project, so we are pre-emptively removing the flag.