### PR TITLE
Update logback to 1.4.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,11 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "2.1.0"
 )
 
+dependencyOverrides ++= Seq(
+  "ch.qos.logback" % "logback-classic" % "1.4.12",
+  "ch.qos.logback" % "logback-core" % "1.4.12",
+)
+
 // Mostly cherry picked from https://tpolecat.github.io/2017/04/25/scalac-flags.html
 scalacOptions ++= Seq(
   "-Xfatal-warnings", // Fail the compilation if there are any warnings.


### PR DESCRIPTION
## What does this change?

Updates logback to 1.4.12 to fix a few [high security vulnerabilities.](https://app.snyk.io/org/guardian-capi/project/93239a95-71d8-4152-b3d0-187e1de0a867)

## How to test

- [x] The project should compile.
- [x] Snyk should give us the [all clear.](https://app.snyk.io/org/guardian-capi/project/2a600b22-cd9c-400f-9cc3-887d19b59f43/history/eb8bb228-eeaa-4115-a32d-6978e9033ce0)
- [ ] The project should run. Waiting on formstack credentials to run the project.
